### PR TITLE
add dates previous selected when open the calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## [0.3.0] - 2020-11-26
+
+- Fixed a bug that the End Date could not be the same as de Initial Date.
+- Added the possibility to open the calendar with dates already selected (One date, two dates, or none).
+
 ## [0.2.0] - 2020-11-25
 
-- Added the possibility to show disabled dates the First and Last Month, these dates are the dates that are previous `minDate` and post `maxDate`
+- Added the possibility to show disabled dates the First and Last Month, these dates are the dates that are previous `minDate` and post `maxDate`.
 - Fix a bug that the next Month displayed with empty values when the `maxDate` occurs on the last week of the month.
 
 ## [0.1.1] - 2020-10-28
@@ -12,5 +17,5 @@
 
 - Added calendar full page with a scroll in the vertical.
 - Added a select a range date with special colors.
-- Added capture of the date selected
-- Change calendar with Locale
+- Added capture of the date selected.
+- Change calendar with Locale.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Scrollable clean calendar
 
-A clean widget calendar with vertical scroll, locale, and range selection date.
+A clean calendar widget with vertical scroll, locale, and range selection date.
 
 ## Instalation
 
-Add `scrollable_clean_calendar: 0.2.0` in your `pubspec.yaml`.
+Add `scrollable_clean_calendar: 0.3.0` in your `pubspec.yaml`.
 
 ## Locale
 
@@ -29,6 +29,8 @@ Example `locale: 'pt'`
 | selectDateRadius                | false    | double    | Apply radius when selected two dates                                                                       |
 | renderPostAndPreviousMonthDates | false    | bool      | Show the dates of the first Month before the `minDate` and the dates of the last Month after the `maxDate` |
 | disabledDateColor               | false    | Color     | Color of the disabled dates                                                                                |
+| initialDateSelected             | false    | DateTime  | First date that is already selected when the calendar Init                                                 |
+| endDateSelected                 | false    | DateTime  | Last date that is already selected when the calendar Init                                                  |
 
 ## Locale en
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Example `locale: 'pt'`
 
 ## Locale en
 
-[![Captura-de-Tela-2020-10-28-a-s-22-03-12.png](https://i.postimg.cc/VkJn9MxV/Captura-de-Tela-2020-10-28-a-s-22-03-12.png)](https://postimg.cc/BjGj48QT)
+[![Simulator-Screen-Shot-i-Phone-11-2020-11-26-at-14-38-24.png](https://i.postimg.cc/8znFXH9h/Simulator-Screen-Shot-i-Phone-11-2020-11-26-at-14-38-24.png)](https://postimg.cc/mPC2tQbD)
 
 ## Locale pt
 
-[![Captura-de-Tela-2020-10-28-a-s-21-40-18.png](https://i.postimg.cc/nzjP6C9R/Captura-de-Tela-2020-10-28-a-s-21-40-18.png)](https://postimg.cc/G8RKD3QG)
+[![Simulator-Screen-Shot-i-Phone-11-2020-11-26-at-14-38-53.png](https://i.postimg.cc/PqpCgDn0/Simulator-Screen-Shot-i-Phone-11-2020-11-26-at-14-38-53.png)](https://postimg.cc/v1y89cBv)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
           onTapDate: (date) {
             print('onTap $date');
           },
-          locale: 'en', //default is en
+          locale: 'pt', //default is en
           minDate: DateTime.now(),
           maxDate: DateTime.now().add(
             Duration(days: 365),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -101,7 +101,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/scrollable_clean_calendar.dart
+++ b/lib/scrollable_clean_calendar.dart
@@ -37,6 +37,8 @@ class ScrollableCleanCalendar extends StatefulWidget {
     this.renderPostAndPreviousMonthDates = false,
     this.disabledDateColor,
     this.startWeekDay = DateTime.monday,
+    this.initialDateSelected,
+    this.endDateSelected,
   })  : assert(minDate != null),
         assert(maxDate != null),
         assert(showDaysWeeks != null),
@@ -48,6 +50,8 @@ class ScrollableCleanCalendar extends StatefulWidget {
   final bool renderPostAndPreviousMonthDates;
   final DateTime minDate;
   final DateTime maxDate;
+  final DateTime initialDateSelected;
+  final DateTime endDateSelected;
 
   /// Esse parametro sera habilitado em futuras versoes
   @deprecated
@@ -97,6 +101,18 @@ class _ScrollableCleanCalendarState extends State<ScrollableCleanCalendar> {
 
     _cleanCalendarController =
         CleanCalendarController(startWeekDay: widget.startWeekDay);
+
+    if (widget.initialDateSelected != null &&
+        (widget.initialDateSelected.isAfter(widget.minDate) ||
+            widget.initialDateSelected.isSameDay(widget.minDate))) {
+      _onDayClick(widget.initialDateSelected);
+    }
+
+    if (widget.endDateSelected != null &&
+        (widget.endDateSelected.isBefore(widget.maxDate) ||
+            widget.endDateSelected.isSameDay(widget.maxDate))) {
+      _onDayClick(widget.endDateSelected);
+    }
 
     super.initState();
   }
@@ -328,7 +344,7 @@ class _ScrollableCleanCalendarState extends State<ScrollableCleanCalendar> {
         rangeMaxDate = rangeMinDate;
         rangeMinDate = date;
       });
-    } else if (date.isAfter(rangeMinDate)) {
+    } else if (date.isAfter(rangeMinDate) || date.isSameDay(rangeMinDate)) {
       setState(() {
         rangeMaxDate = date;
       });

--- a/lib/scrollable_clean_calendar.dart
+++ b/lib/scrollable_clean_calendar.dart
@@ -219,6 +219,8 @@ class _ScrollableCleanCalendarState extends State<ScrollableCleanCalendar> {
                   _onDayClick(day);
                 },
                 child: Container(
+                  key: ValueKey(
+                      '${DateFormat('dd-MM-yyyy', widget.locale).format(day)}_container'),
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.horizontal(
                       left: Radius.circular(

--- a/lib/src/clean_calendar_controller.dart
+++ b/lib/src/clean_calendar_controller.dart
@@ -33,7 +33,7 @@ class CleanCalendarController {
     while (today.weekday != startWeekDay) {
       today = today.subtract(Duration(days: 1));
     }
-    final dateFormat = DateFormat(DateFormat.NUM_MONTH_WEEKDAY_DAY);
+
     final daysOfWeek = [
       today.weekday,
       today.add(Duration(days: 1)).weekday,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scrollable_clean_calendar
-description: A clean widget calendar with vertical scroll
-version: 0.2.0
+description: A clean widget calendar with vertical scroll, locale, and range selection date
+version: 0.3.0
 author: Fabio
 homepage: https://github.com/FabioFiuza/scrollable_clean_calendar
 

--- a/test/scrollable_clean_calendar_test.dart
+++ b/test/scrollable_clean_calendar_test.dart
@@ -17,6 +17,7 @@ void main() {
     bool renderPostAndPreviousMonthDates,
     DateTime initialDateSelected,
     DateTime endDateSelected,
+    Color selectedDateColor,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -36,6 +37,7 @@ void main() {
                 renderPostAndPreviousMonthDates ?? false,
             initialDateSelected: initialDateSelected,
             endDateSelected: endDateSelected,
+            selectedDateColor: selectedDateColor ?? Colors.amber,
           ),
         ),
       ),
@@ -189,25 +191,19 @@ void main() {
       minDate: DateTime(2020, 2, 15),
       maxDate: DateTime(2020, 3, 15),
       initialDateSelected: DateTime(2020, 2, 20),
-      onTapDate: (date) {
-        expect(dateFormat.format(date), '20-02-2020');
-      },
-    ));
-  });
-
-  testWidgets(
-      'When endDateSelected is not null, the calendar should open with the date already selected',
-      (WidgetTester tester) async {
-    final dateFormat = DateFormat('dd-MM-yyyy');
-
-    await tester.pumpWidget(buildScrollableCleanCalendar(
-      locale: 'pt',
-      minDate: DateTime(2020, 2, 15),
-      maxDate: DateTime(2020, 3, 15),
       endDateSelected: DateTime(2020, 2, 25),
-      onTapDate: (date) {
-        expect(dateFormat.format(date), '25-02-2020');
-      },
+      selectedDateColor: Colors.red,
     ));
+
+    final initialDateContainer = tester
+        .firstWidget(find.byKey(ValueKey('20-02-2020_container'))) as Container;
+
+    expect(
+        ((initialDateContainer.decoration) as BoxDecoration).color, Colors.red);
+
+    final endDateContainer = tester
+        .firstWidget(find.byKey(ValueKey('25-02-2020_container'))) as Container;
+
+    expect(((endDateContainer.decoration) as BoxDecoration).color, Colors.red);
   });
 }

--- a/test/scrollable_clean_calendar_test.dart
+++ b/test/scrollable_clean_calendar_test.dart
@@ -15,6 +15,8 @@ void main() {
     SelectDate onTapDate,
     int startWeekDay,
     bool renderPostAndPreviousMonthDates,
+    DateTime initialDateSelected,
+    DateTime endDateSelected,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -32,6 +34,8 @@ void main() {
             startWeekDay: startWeekDay ?? DateTime.monday,
             renderPostAndPreviousMonthDates:
                 renderPostAndPreviousMonthDates ?? false,
+            initialDateSelected: initialDateSelected,
+            endDateSelected: endDateSelected,
           ),
         ),
       ),
@@ -156,5 +160,54 @@ void main() {
 
     var postDateOfMonth = find.byKey(ValueKey('20-05-2020'));
     expect(postDateOfMonth, findsOneWidget);
+  });
+
+  testWidgets(
+      'When the same date is clicked twice it should return it in both dates',
+      (WidgetTester tester) async {
+    final dateFormat = DateFormat('dd-MM-yyyy');
+
+    await tester.pumpWidget(
+        buildScrollableCleanCalendar(onRangeSelected: (firstDate, secondDate) {
+      expect(dateFormat.format(firstDate), '05-01-2020');
+      if (secondDate != null) {
+        expect(dateFormat.format(secondDate), '05-01-2020');
+      }
+    }));
+
+    await tester.tap(find.byKey(ValueKey('05-01-2020')));
+    await tester.tap(find.byKey(ValueKey('05-01-2020')));
+  });
+
+  testWidgets(
+      'When initialDateSelected is not null, the calendar should open with the date already selected',
+      (WidgetTester tester) async {
+    final dateFormat = DateFormat('dd-MM-yyyy');
+
+    await tester.pumpWidget(buildScrollableCleanCalendar(
+      locale: 'pt',
+      minDate: DateTime(2020, 2, 15),
+      maxDate: DateTime(2020, 3, 15),
+      initialDateSelected: DateTime(2020, 2, 20),
+      onTapDate: (date) {
+        expect(dateFormat.format(date), '20-02-2020');
+      },
+    ));
+  });
+
+  testWidgets(
+      'When endDateSelected is not null, the calendar should open with the date already selected',
+      (WidgetTester tester) async {
+    final dateFormat = DateFormat('dd-MM-yyyy');
+
+    await tester.pumpWidget(buildScrollableCleanCalendar(
+      locale: 'pt',
+      minDate: DateTime(2020, 2, 15),
+      maxDate: DateTime(2020, 3, 15),
+      endDateSelected: DateTime(2020, 2, 25),
+      onTapDate: (date) {
+        expect(dateFormat.format(date), '25-02-2020');
+      },
+    ));
   });
 }


### PR DESCRIPTION
- Fixed a bug that the End Date could not be the same as de Initial Date.
- Added the possibility to open the calendar with dates already selected (One date, two dates, or none).