### PR TITLE
Updates flutter_lints and changes its location on pubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.3.0] - 2022-07-20
+## [1.3.1] - 2022-07-20
 
 - Updated flutter_lints and moved it from direct dependency to dev dependency which fix incompatibility with updated Flutter 3 projects
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.0] - 2022-07-20
+
+- Updated flutter_lints and moved it from direct dependency to dev dependency which fix incompatibility with updated Flutter 3 projects
+
 ## [1.3.0] - 2022-07-04 (**Breakchanges**)
 
 - Remove property `scrollController`.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,9 +29,9 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: const ColorScheme(
           primary: Color(0xFF3F51B5),
-          primaryVariant: Color(0xFF002984),
+          primaryContainer: Color(0xFF002984),
           secondary: Color(0xFFD32F2F),
-          secondaryVariant: Color(0xFF9A0007),
+          secondaryContainer: Color(0xFF9A0007),
           surface: Color(0xFFDEE2E6),
           background: Color(0xFFF8F9FA),
           error: Color(0xFF96031A),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -108,7 +108,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1"
   scrollable_positioned_list:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -62,13 +62,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_lints:
-    dependency: transitive
-    description:
-      name: flutter_lints
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -81,13 +74,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
-  lints:
-    dependency: transitive
-    description:
-      name: lints
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -122,7 +108,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   scrollable_positioned_list:
     dependency: transitive
     description:

--- a/lib/scrollable_clean_calendar.dart
+++ b/lib/scrollable_clean_calendar.dart
@@ -106,7 +106,7 @@ class ScrollableCleanCalendar extends StatefulWidget {
                 dayBuilder != null));
 
   @override
-  _ScrollableCleanCalendarState createState() =>
+  State<ScrollableCleanCalendar> createState() =>
       _ScrollableCleanCalendarState();
 }
 

--- a/lib/widgets/month_widget.dart
+++ b/lib/widgets/month_widget.dart
@@ -24,11 +24,8 @@ class MonthWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final text = DateFormat('MMMM', locale)
-            .format(DateTime(month.year, month.month))
-            .capitalize() +
-        ' ' +
-        DateFormat('yyyy', locale).format(DateTime(month.year, month.month));
+    final text =
+        '${DateFormat('MMMM', locale).format(DateTime(month.year, month.month)).capitalize()} ${DateFormat('yyyy', locale).format(DateTime(month.year, month.month))}';
 
     if (monthBuilder != null) {
       return monthBuilder!(context, text);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -56,12 +56,12 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_lints:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,7 +80,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
@@ -171,5 +171,5 @@ packages:
     source: hosted
     version: "2.1.2"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=2.12.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/FabioFiuza/scrollable_clean_calendar
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=2.7.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.17.0
-  flutter_lints: ^1.0.4
   scrollable_positioned_list: ^0.3.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^2.0.1
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scrollable_clean_calendar
 description: A clean calendar widget with vertical scroll, locale, and range selection date
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/FabioFiuza/scrollable_clean_calendar
 
 environment:


### PR DESCRIPTION
- Updated flutter_lints to 2.0.1
- Moved it from a direct dependency to a dev dependency (where it should be) which fix incompatibility with updated Flutter 3 projects
- Fixed the new lint warnings
- Updated changelog