### PR TITLE
Add options to hide weeks outside minDate and maxDate ranges

### DIFF
--- a/lib/controllers/clean_calendar_controller.dart
+++ b/lib/controllers/clean_calendar_controller.dart
@@ -10,6 +10,14 @@ class CleanCalendarController extends ChangeNotifier {
   /// Obrigatory: The maximum date to show
   final DateTime maxDate;
 
+  /// Whether to hide entire weeks if any days in them
+  /// fall before the [minDate].
+  final bool hideWeeksOutOfMinDate;
+
+  /// Whether to hide entire weeks if any days in them
+  /// fall after the [maxDate].
+  final bool hideWeeksOutOfMaxDate;
+
   /// If the range is enabled
   final bool rangeMode;
 
@@ -59,6 +67,8 @@ class CleanCalendarController extends ChangeNotifier {
     this.onPreviousMinDateTapped,
     this.weekdayStart = DateTime.monday,
     this.initialFocusDate,
+    this.hideWeeksOutOfMinDate = false,
+    this.hideWeeksOutOfMaxDate = false,
   })  : assert(weekdayStart <= DateTime.sunday),
         assert(weekdayStart >= DateTime.monday) {
     final x = weekdayStart - 1;

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -32,5 +32,24 @@ extension DateUtilsExtensions on DateTime {
   bool isSameDay(DateTime other) =>
       year == other.year && month == other.month && day == other.day;
 
+  bool isSameMonth(DateTime other) =>
+      year == other.year && month == other.month;
+
   DateTime removeTime() => DateTime(year, month, day);
+
+  DateTime firstDayOfMonth() => DateTime(year, month, 1);
+
+  DateTime lastDayOfMonth() => DateTime(year, month + 1, 0);
+
+  /// Returns the first day of the week based on the provided [weekdayStart].
+  DateTime firstDayOfWeek(int weekdayStart) {
+    int daysToSubtract = (weekday - weekdayStart) % 7;
+    return subtract(Duration(days: daysToSubtract));
+  }
+
+  /// Returns the last day of the week based on the provided [weekdayEnd].
+  DateTime lastDayOfWeek(int weekdayEnd) {
+    int daysToAdd = (weekdayEnd - weekday) % 7;
+    return add(Duration(days: daysToAdd));
+  }
 }


### PR DESCRIPTION
In certain situations, there’s a need to avoid displaying the full month when the current date falls near the end or middle of the month. This PR introduces options to hide entire weeks that fall outside the specified minDate and maxDate range.