### PR TITLE
Make day disable text decoration configurable

### DIFF
--- a/lib/scrollable_clean_calendar.dart
+++ b/lib/scrollable_clean_calendar.dart
@@ -86,6 +86,9 @@ class ScrollableCleanCalendar extends StatefulWidget {
   /// The controller of ScrollableCleanCalendar
   final CleanCalendarController calendarController;
 
+  /// The decoration of disable day text, default is TextDecoration.lineThrough
+  final TextDecoration? dayDisableTextDecoration;
+
   const ScrollableCleanCalendar({
     this.locale = 'en',
     this.scrollController,
@@ -112,6 +115,7 @@ class ScrollableCleanCalendar extends StatefulWidget {
     this.dayAspectRatio,
     this.dayRadius = 6,
     required this.calendarController,
+    this.dayDisableTextDecoration,
   }) : assert(layout != null ||
             (monthBuilder != null &&
                 weekdayBuilder != null &&
@@ -222,6 +226,7 @@ class _ScrollableCleanCalendarState extends State<ScrollableCleanCalendar> {
                   radius: widget.dayRadius,
                   textStyle: widget.dayTextStyle,
                   aspectRatio: widget.dayAspectRatio,
+                  dayDisableTextDecoration: widget.dayDisableTextDecoration,
                 );
               },
             )

--- a/lib/widgets/days_widget.dart
+++ b/lib/widgets/days_widget.dart
@@ -22,6 +22,7 @@ class DaysWidget extends StatelessWidget {
   final double radius;
   final TextStyle? textStyle;
   final double? aspectRatio;
+  final TextDecoration? dayDisableTextDecoration;
 
   const DaysWidget({
     Key? key,
@@ -39,6 +40,7 @@ class DaysWidget extends StatelessWidget {
     required this.radius,
     required this.textStyle,
     required this.aspectRatio,
+    this.dayDisableTextDecoration = TextDecoration.lineThrough,
   }) : super(key: key);
 
   @override
@@ -189,7 +191,7 @@ class DaysWidget extends StatelessWidget {
       txtStyle = (textStyle ?? Theme.of(context).textTheme.bodyLarge)!.copyWith(
         color: dayDisableColor ??
             Theme.of(context).colorScheme.onSurface.withOpacity(.5),
-        decoration: TextDecoration.lineThrough,
+        decoration: dayDisableTextDecoration,
       );
     }
 


### PR DESCRIPTION
This PR introduces a new property `dayDisableTextDecoration`, allowing customization of the text decoration for disabled days. The default value is set to TextDecoration.lineThrough to maintain previous behavior. 

This change makes the widget more flexible, allowing different text decorations as needed.